### PR TITLE
Update pre-commit hooks and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,36 +8,36 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-type: "all"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     groups:
       production-version-updates:
         applies-to: version-updates
         dependency-type: production
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       production-security-updates:
         applies-to: security-updates
         dependency-type: production
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       development-version-updates:
         applies-to: version-updates
         dependency-type: development
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"
       development-security-updates:
         applies-to: security-updates
         dependency-type: development
         update-types:
-          - 'patch'
-          - 'minor'
+          - "patch"
+          - "minor"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,13 @@ repos:
       - id: prettier
         args: [--write, --config=.prettierrc]
   - repo: https://github.com/pycqa/isort
-    rev: 8.0.1
+    rev: 9.0.0a3
     hooks:
       - id: isort
         name: isort (python)
         args: [--settings-file=pyproject.toml] # Configure in pyproject.toml
   - repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black # Configure in pyproject.toml
   - repo: local

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,7 +204,7 @@ version = "7.14.3"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "test"]
+groups = ["test"]
 files = [
     {file = "coverage-7.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360bec1f58e7243e3405d3bdf7a1a8115aa9b448d54dc7cd6f7b7e0e9406b62e"},
     {file = "coverage-7.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed68faa5e85de2f3e400bc3f122e5c82735a58c8bb24b9f63a2215954ba17b2d"},


### PR DESCRIPTION
- Bump isort to 9.0.0a3 and black to 26.5.1 in pre-commit config
- Change dependabot schedule from weekly to monthly
- Reduce pip open-pull-requests-limit from 99 to 5
- Normalize single quotes to double quotes in dependabot.yml
